### PR TITLE
Correct the run_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Just include `hostname` in your node's `run_list`:
 {
   "name":"my_node",
   "run_list": [
-    "recipe[hostname]"
+    "recipe[et_hostname]"
   ]
 }
 ```


### PR DESCRIPTION
In metadata.rb the name of the cookbook is `et_hostname` so I am pretty sure it should also be et_hostname in the run_list.